### PR TITLE
Add import setuptools.dist to __init__.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,5 @@ To install from a specific branch, append `@<branch_name>` to the URL, for examp
 ```
 pip install multitask_unit_and_days@git+https://github.com/EpiForeSITE/multitask_unit_and_days@make-package
 ```
-The next tool needed is `distutils`, which is not imported automatically. Import this in the container's Python Tty environment using 
-```
-import setuptools.dist
-```
-Finally, the package can be imported using 
-```
-import multitask_unit_and_days
-```
 
 

--- a/multitask_unit_and_days/__init__.py
+++ b/multitask_unit_and_days/__init__.py
@@ -1,4 +1,4 @@
-
+import setuptools.dist
 # from multitask_unit_and_days import DataManager
 # from multitask_unit_and_days import MultiTaskModel
 # from multitask_unit_and_days import run_experiments


### PR DESCRIPTION
Fixed issue where `distutils` needed to be imported before importing the package, by adding `import setuptools.dist` to `__init__.py`